### PR TITLE
add resource to r link for auto open

### DIFF
--- a/.github/workflows/autoupdater.yml
+++ b/.github/workflows/autoupdater.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.STARTER_CODE_TOKEN }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.13'
           cache: 'pip' # caching pip dependencies
 
       - run: pip install -r requirements.txt

--- a/_templates/template_rmarkdown.Rmd
+++ b/_templates/template_rmarkdown.Rmd
@@ -2,6 +2,7 @@
 title: "{{ DOCUMENT_TITLE }}"
 date: "{{ TODAY_DATE }}"
 output: html_document
+editor: visual
 ---
 
 ## Dataset: {{ DATASET_TITLE }}

--- a/_templates/template_rmarkdown_geo.Rmd
+++ b/_templates/template_rmarkdown_geo.Rmd
@@ -2,6 +2,7 @@
 title: "{{ DOCUMENT_TITLE }}"
 date: "{{ TODAY_DATE }}"
 output: html_document
+editor: visual
 ---
 
 ## Dataset: {{ DATASET_TITLE }}

--- a/updater.py
+++ b/updater.py
@@ -399,7 +399,7 @@ def create_overview(data, header):
         py_colab_link = f"[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)]({baselink_py_colab}{filename}.ipynb)"
         py_binder_link = f"[![Jupyter Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/{GITHUB_ACCOUNT}/{REPO_NAME}/{REPO_BRANCH}?filepath={REPO_PYTHON_OUTPUT}{filename}.ipynb)"
         py_renku_link = f"[![Python - renku](https://renkulab.io/renku-badge.svg)]({baselink_py_renku}start?PACKAGE_ID={data.loc[idx, 'name']}&RESOURCE_ID={data.loc[idx, PREFIX_RESOURCE_COLS+'id']})"
-        r_renku_link = f"[![R - renku](https://renkulab.io/renku-badge.svg)]({baselink_r_renku}start?PACKAGE_ID={data.loc[idx, 'name']})"
+        r_renku_link = f"[![R - renku](https://renkulab.io/renku-badge.svg)]({baselink_r_renku}start?PACKAGE_ID={data.loc[idx, 'name']}&RESOURCE_ID={data.loc[idx, PREFIX_RESOURCE_COLS+'id']})"
 
 
         fileformat = data.loc[idx,PREFIX_RESOURCE_COLS+'format'].lower()


### PR DESCRIPTION
Renku RStudio now auto opens the correct ressource, if provided (see the [PR](https://github.com/opendatazurich/opendatazurich_renku_r/pull/4)).
So we need to add the ressource id to the url.

Plus: Update Github Actions Versions to prevent NodeJS deprecation.